### PR TITLE
Add shared word count utility

### DIFF
--- a/src/services/assembly.ts
+++ b/src/services/assembly.ts
@@ -8,6 +8,7 @@ import { StorageService } from './storage.js';
 import { StoryService } from './story.js';
 import { MessageService } from './message.js';
 import { logger } from '@/config/logger.js';
+import { countWords } from '@/shared/utils.js';
 
 export interface AssemblyResult {
   files: {
@@ -123,7 +124,7 @@ export class AssemblyService {
           pdf: pdfUrl
         },        metadata: {
           title: story.title, // Use title from database
-          wordCount: this.countWords(chapters.map(c => c.content).join(' ')),
+          wordCount: countWords(chapters.map(c => c.content).join(' ')),
           pageCount: Math.ceil(chapters.length / 2), // Rough estimate
           generatedAt: new Date().toISOString()
         }
@@ -313,7 +314,4 @@ ${creditsMessage}
     return Buffer.from(content, 'utf-8');
   }
 
-  private countWords(text: string): number {
-    return text.split(/\s+/).filter(word => word.length > 0).length;
-  }
 }

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -6,6 +6,7 @@
 import { RunsService } from './runs.js';
 import { StorageService } from './storage.js';
 import { logger } from '@/config/logger.js';
+import { countWords } from '@/shared/utils.js';
 
 export interface TTSResult {
   audioUrl: string;
@@ -75,7 +76,7 @@ export class TTSService {
         duration: this.estimateDuration(fullText),
         format: 'mp3',
         metadata: {
-          totalWords: this.countWords(fullText),
+          totalWords: countWords(fullText),
           generatedAt: new Date().toISOString()
         }
       };
@@ -139,12 +140,9 @@ export class TTSService {
 
   private estimateDuration(text: string): number {
     // Rough estimation: average speaking rate is ~150 words per minute
-    const wordCount = this.countWords(text);
+    const wordCount = countWords(text);
     const wordsPerMinute = 150;
     return Math.ceil((wordCount / wordsPerMinute) * 60); // return seconds
   }
 
-  private countWords(text: string): number {
-    return text.split(/\s+/).filter(word => word.length > 0).length;
-  }
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -42,6 +42,10 @@ export function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+export function countWords(text: string): number {
+  return text.split(/\s+/).filter(word => word.length > 0).length;
+}
+
 export async function retry<T>(
   fn: () => Promise<T>,
   maxRetries: number = 3,

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from '@jest/globals';
+import { countWords } from '@/shared/utils';
+
+describe('countWords utility', () => {
+  it('should correctly count words in a string', () => {
+    expect(countWords('Hello world')).toBe(2);
+    expect(countWords('  multiple   spaces\nbetween words ')).toBe(4);
+    expect(countWords('')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `countWords` in shared utils
- use shared `countWords` in `AssemblyService` and `TTSService`
- add unit test for `countWords`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851e6d6bbac8328ba1eeeb16ef00ee7