### PR TITLE
Refactor image route helpers

### DIFF
--- a/src/routes/ai-image-utils.ts
+++ b/src/routes/ai-image-utils.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+// Schema for image generation requests
+export const ImageRequestSchema = z.object({
+  prompt: z.string().min(1),
+  storyId: z.string().uuid(),
+  runId: z.string().uuid(),
+  chapterNumber: z.number().int().positive().optional(),
+  imageType: z.enum(['front_cover', 'back_cover', 'chapter']).optional(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
+  style: z.enum(['vivid', 'natural']).optional()
+});
+
+export type ImageRequest = z.infer<typeof ImageRequestSchema>;
+
+/**
+ * Validate and parse the image generation request body.
+ */
+export function validateImageRequest(data: unknown): ImageRequest {
+  return ImageRequestSchema.parse(data);
+}
+
+/**
+ * Generate a filename for an image based on story context and type.
+ */
+export function generateImageFilename(params: {
+  storyId: string;
+  imageType?: 'front_cover' | 'back_cover' | 'chapter';
+  chapterNumber?: number;
+  timestamp?: string;
+}): string {
+  const { storyId, imageType, chapterNumber } = params;
+  const timestamp = params.timestamp ?? new Date().toISOString().replace(/[:.]/g, '-');
+
+  if (imageType === 'front_cover') {
+    return `${storyId}/images/frontcover_${timestamp}.png`;
+  }
+  if (imageType === 'back_cover') {
+    return `${storyId}/images/backcover_${timestamp}.png`;
+  }
+  if (chapterNumber) {
+    return `${storyId}/images/chapter_${chapterNumber}_${timestamp}.png`;
+  }
+  return `${storyId}/images/image_${timestamp}.png`;
+}
+
+/**
+ * Format an error object with request context for logging and responses.
+ */
+export function formatImageError(error: unknown, reqData: Partial<ImageRequest>, currentStep: string): Record<string, unknown> {
+  return {
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+    name: error instanceof Error ? error.name : undefined,
+    storyId: reqData.storyId,
+    runId: reqData.runId,
+    chapterNumber: reqData.chapterNumber,
+    timestamp: new Date().toISOString(),
+    currentStep,
+    requestDetails: {
+      promptLength: reqData.prompt?.length,
+      dimensions: reqData.width && reqData.height ? `${reqData.width}x${reqData.height}` : 'default',
+      style: reqData.style
+    }
+  };
+}
+

--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -7,6 +7,11 @@ import { Router } from 'express';
 import { AIGateway } from '../ai/gateway.js';
 import { logger } from '@/config/logger.js';
 import { z } from 'zod';
+import {
+  validateImageRequest,
+  generateImageFilename,
+  formatImageError
+} from './ai-image-utils.js';
 import { StoryService } from '@/services/story.js';
 import { PromptService } from '@/services/prompt.js';
 import { SchemaService } from '@/services/schema.js';
@@ -52,16 +57,6 @@ const ChapterRequestSchema = z.object({
   previousChapters: z.array(z.string()).optional()
 });
 
-const ImageRequestSchema = z.object({
-  prompt: z.string().min(1),
-  storyId: z.string().uuid(),
-  runId: z.string().uuid(),
-  chapterNumber: z.number().int().positive().optional(),
-  imageType: z.enum(['front_cover', 'back_cover', 'chapter']).optional(),
-  width: z.number().int().positive().optional(),
-  height: z.number().int().positive().optional(),
-  style: z.enum(['vivid', 'natural']).optional()
-});
 
 /**
  * POST /ai/text/outline
@@ -281,7 +276,10 @@ router.post('/text/chapter/:chapterNumber', async (req, res) => {
 router.post('/image', async (req, res) => {
   let currentStep = 'parsing_request';
   try {
-    const { prompt, storyId, runId, chapterNumber, imageType, width, height, style } = ImageRequestSchema.parse(req.body); logger.info('AI Gateway: Generating image', {
+    const { prompt, storyId, runId, chapterNumber, imageType, width, height, style } =
+      validateImageRequest(req.body);
+
+    logger.info('AI Gateway: Generating image', {
       storyId,
       runId,
       chapterNumber,
@@ -303,24 +301,10 @@ router.post('/image', async (req, res) => {
       chapterNumber,
       imageSize: imageBuffer.length
     });
-    
-    // Create filename with story folder organization
-    // Format: {storyId}/images/chapter_{chapterNumber}_{timestamp}.png OR frontcover_{timestamp}.png OR backcover_{timestamp}.png
-    currentStep = 'preparing_upload';
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    let filename: string;
-    if (imageType === 'front_cover') {
-      filename = `${storyId}/images/frontcover_${timestamp}.png`;
-    } else if (imageType === 'back_cover') {
-      filename = `${storyId}/images/backcover_${timestamp}.png`;
-    } else if (chapterNumber) {
-      filename = `${storyId}/images/chapter_${chapterNumber}_${timestamp}.png`;
-    } else {
-      // Fallback for when imageType is not specified but chapterNumber is not provided
-      filename = `${storyId}/images/image_${timestamp}.png`;
-    }
 
-    // Upload image to Google Cloud Storage
+    currentStep = 'preparing_upload';
+    const filename = generateImageFilename({ storyId, imageType, chapterNumber });
+
     currentStep = 'uploading_to_storage';
     const imageUrl = await storageService.uploadFile(filename, imageBuffer, 'image/png');
 
@@ -346,33 +330,14 @@ router.post('/image', async (req, res) => {
       }
     });
   } catch (error) {
-    // Enhanced error logging with detailed context
-    const errorDetails = {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      name: error instanceof Error ? error.name : undefined,
-      storyId: req.body.storyId,
-      runId: req.body.runId,
-      chapterNumber: req.body.chapterNumber,
-      timestamp: new Date().toISOString(),
-      currentStep, // Track which step failed
-      requestDetails: {
-        promptLength: req.body.prompt?.length,
-        dimensions: req.body.width && req.body.height ? `${req.body.width}x${req.body.height}` : 'default',
-        style: req.body.style
-      }
-    };
-
+    const errorDetails = formatImageError(error, req.body, currentStep);
     logger.error('AI Gateway: Image generation or upload failed', errorDetails);
-
-    // Return a more informative error response
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
 
     res.status(500).json({
       success: false,
-      error: errorMessage,
+      error: errorDetails.message,
       failedAt: currentStep,
-      timestamp: new Date().toISOString(),
+      timestamp: errorDetails.timestamp,
       requestId: req.body.runId || 'unknown'
     });
   }


### PR DESCRIPTION
## Summary
- extract image request helper utilities
- streamline `/ai/image` route
- update imports for new helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685260dc27388328867b62986b37a3cd