### PR TITLE
Add unit tests for core Story and Token usage services

### DIFF
--- a/src/tests/story.test.ts
+++ b/src/tests/story.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('@/config/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/db/connection', () => ({
+  getDatabase: jest.fn(),
+}));
+
+jest.mock('@/shared/utils', () => ({
+  retry: jest.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+import { StoryService } from '../services/story';
+import { getDatabase } from '@/db/connection';
+import { retry } from '@/shared/utils';
+import { logger } from '@/config/logger';
+
+describe('StoryService', () => {
+  let service: StoryService;
+  let mockDb: any;
+
+  beforeEach(() => {
+    mockDb = {
+      select: jest.fn(),
+      update: jest.fn(),
+    };
+    (getDatabase as jest.Mock).mockReturnValue(mockDb);
+    service = new StoryService();
+    jest.clearAllMocks();
+  });
+
+  it('should return true when story exists', async () => {
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([{ storyId: 's1' }]),
+        }),
+      }),
+    });
+
+    const result = await service.storyExists('s1');
+    expect(result).toBe(true);
+  });
+
+  it('should return false when story does not exist', async () => {
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const result = await service.storyExists('s1');
+    expect(result).toBe(false);
+  });
+
+  it('should return null for invalid storyId', async () => {
+    const result = await service.getStoryContext('');
+    expect(result).toBeNull();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('should load story context with characters', async () => {
+    const story = {
+      storyId: 's1',
+      authorId: 'a1',
+      title: 'Title',
+      plotDescription: null,
+      synopsis: null,
+      place: null,
+      additionalRequests: null,
+      targetAudience: null,
+      novelStyle: null,
+      graphicalStyle: null,
+      storyLanguage: 'en',
+      chapterCount: 2,
+    };
+    const characters = [
+      {
+        characterId: 'c1',
+        name: 'Hero',
+        type: null,
+        age: null,
+        traits: null,
+        characteristics: null,
+        physicalDescription: null,
+        role: 'lead',
+      },
+    ];
+
+    mockDb.select
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([story]),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          innerJoin: jest.fn().mockReturnValue({
+            where: jest.fn().mockResolvedValue(characters),
+          }),
+        }),
+      });
+
+    const result = await service.getStoryContext('s1');
+    expect(result?.story.title).toBe('Title');
+    expect(result?.characters).toHaveLength(1);
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('should update story URIs with retry', async () => {
+    const whereMock = jest.fn().mockResolvedValue(undefined);
+    const setMock = jest.fn().mockReturnValue({ where: whereMock });
+    mockDb.update.mockReturnValue({ set: setMock });
+
+    const updates = { htmlUri: 'html', hasAudio: true };
+    const result = await service.updateStoryUris('s1', updates);
+
+    expect(result).toBe(true);
+    expect(retry).toHaveBeenCalled();
+    expect(setMock).toHaveBeenCalledWith(updates);
+  });
+
+  it('should group chapters in getStoryForPrint', async () => {
+    const story = {
+      storyId: 's1',
+      title: 'Title',
+      customAuthor: null,
+      dedicationMessage: null,
+      coverUri: null,
+      backcoverUri: null,
+      chapterCount: 2,
+      storyLanguage: 'en',
+      createdAt: new Date(),
+      synopsis: null,
+      graphicalStyle: null,
+      targetAudience: null,
+    };
+
+    const chaptersData = [
+      { chapterNumber: 1, title: 'A2', content: 'v2', imageUri: 'i2', version: 2 },
+      { chapterNumber: 1, title: 'A', content: 'v1', imageUri: 'i1', version: 1 },
+      { chapterNumber: 2, title: 'B', content: 'v1', imageUri: 'i3', version: 1 },
+    ];
+
+    mockDb.select
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([story]),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            orderBy: jest.fn().mockResolvedValue(chaptersData),
+          }),
+        }),
+      });
+
+    const result = await service.getStoryForPrint('s1');
+    expect(result?.chapters).toHaveLength(2);
+    expect(result?.chapters[0].title).toBe('A2');
+    expect(logger.info).toHaveBeenCalled();
+  });
+});
+

--- a/src/tests/token-usage-tracking.test.ts
+++ b/src/tests/token-usage-tracking.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('@/config/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/db/workflows-db', () => ({
+  getWorkflowsDatabase: jest.fn(),
+  tokenUsageTracking: {},
+}));
+
+import { TokenUsageTrackingService } from '../services/token-usage-tracking';
+import { getWorkflowsDatabase } from '@/db/workflows-db';
+import { logger } from '@/config/logger';
+
+describe('TokenUsageTrackingService', () => {
+  let service: TokenUsageTrackingService;
+  let mockDb: any;
+
+  beforeEach(() => {
+    mockDb = {
+      insert: jest.fn(),
+      select: jest.fn(),
+    };
+    (getWorkflowsDatabase as jest.Mock).mockReturnValue(mockDb);
+    service = new TokenUsageTrackingService();
+    jest.clearAllMocks();
+  });
+
+  it('records usage with cost estimation', async () => {
+    const valuesMock = jest.fn().mockResolvedValue(undefined);
+    mockDb.insert.mockReturnValue({ values: valuesMock });
+
+    await service.recordUsage({
+      authorId: 'a1',
+      storyId: 's1',
+      action: 'chapter_writing',
+      aiModel: 'gpt-4',
+      inputTokens: 1000,
+      outputTokens: 500,
+      inputPromptJson: {},
+    });
+
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(valuesMock).toHaveBeenCalled();
+    const usageRecord = valuesMock.mock.calls[0][0];
+    expect(parseFloat(usageRecord.estimatedCostInEuros)).toBeCloseTo(0.0552);
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('calculates cost for OpenAI GPT-4 model', () => {
+    const estimation = (service as any).calculateCost({
+      provider: 'openai',
+      model: 'gpt-4',
+      inputTokens: 1000,
+      outputTokens: 500,
+      estimatedCostInEuros: 0,
+    });
+    expect(estimation.estimatedCostInEuros).toBeCloseTo(0.0552);
+  });
+
+  it('aggregates story usage', async () => {
+    const records = [
+      { action: 'chapter_writing', inputTokens: 100, outputTokens: 50, estimatedCostInEuros: '1' },
+      { action: 'image_generation', inputTokens: 0, outputTokens: 0, estimatedCostInEuros: '0.5' },
+    ];
+
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue(records),
+      }),
+    });
+
+    const result = await service.getStoryUsage('s1');
+    expect(result.totalTokens).toBe(150);
+    expect(result.totalCostEuros).toBeCloseTo(1.5);
+    expect(result.actionBreakdown.chapter_writing.tokens).toBe(150);
+    expect(result.actionBreakdown.image_generation.cost).toBeCloseTo(0.5);
+  });
+
+  it('aggregates author usage with story and action breakdown', async () => {
+    const records = [
+      { storyId: 's1', action: 'chapter_writing', inputTokens: 100, outputTokens: 50, estimatedCostInEuros: '1' },
+      { storyId: 's2', action: 'image_generation', inputTokens: 0, outputTokens: 0, estimatedCostInEuros: '0.5' },
+    ];
+
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue(records),
+      }),
+    });
+
+    const result = await service.getAuthorUsage('a1');
+    expect(result.totalTokens).toBe(150);
+    expect(result.storyBreakdown.s1.tokens).toBe(150);
+    expect(result.actionBreakdown.image_generation.cost).toBeCloseTo(0.5);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add StoryService unit tests for existence check, context loading, URI updates with retry, and print chapter grouping
- add TokenUsageTrackingService tests for cost calculation and usage aggregation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39e7673d88328b8d908fc4d2c9f31