### PR TITLE
Add unit tests for additional workflow services

### DIFF
--- a/src/tests/chapters.test.ts
+++ b/src/tests/chapters.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('@/config/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/db/connection', () => ({
+  getDatabase: jest.fn(),
+}));
+
+jest.mock('@/shared/utils', () => ({
+  retry: jest.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+import { ChaptersService } from '../services/chapters';
+import { getDatabase } from '@/db/connection';
+import { logger } from '@/config/logger';
+
+describe('ChaptersService', () => {
+  let service: ChaptersService;
+  let mockDb: any;
+
+  beforeEach(() => {
+    mockDb = {
+      select: jest.fn(),
+      insert: jest.fn(),
+      update: jest.fn(),
+    };
+    (getDatabase as jest.Mock).mockReturnValue(mockDb);
+    service = new ChaptersService();
+    jest.clearAllMocks();
+  });
+
+  it('saves chapter with incremented version', async () => {
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          orderBy: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([{ version: 1 }]),
+          }),
+        }),
+      }),
+    });
+    const returningMock = jest.fn().mockResolvedValue([{ id: 'c1', version: 2 }]);
+    mockDb.insert.mockReturnValue({
+      values: jest.fn().mockReturnValue({
+        returning: returningMock,
+      }),
+    });
+
+    const result = await service.saveChapter({
+      storyId: 's1',
+      authorId: 'a1',
+      chapterNumber: 1,
+      title: 'T',
+      htmlContent: '<p></p>',
+    });
+
+    expect(result.version).toBe(2);
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('updates chapter image for latest version', async () => {
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          orderBy: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([{ id: 'id1', version: 2 }]),
+          }),
+        }),
+      }),
+    });
+
+    const whereMock = jest.fn().mockResolvedValue(undefined);
+    mockDb.update.mockReturnValue({
+      set: jest.fn().mockReturnValue({ where: whereMock }),
+    });
+
+    await service.updateChapterImage('s1', 1, 'img');
+
+    expect(whereMock).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('updates chapter audio for latest version', async () => {
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          orderBy: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([{ id: 'id1', version: 2 }]),
+          }),
+        }),
+      }),
+    });
+
+    const whereMock = jest.fn().mockResolvedValue(undefined);
+    mockDb.update.mockReturnValue({
+      set: jest.fn().mockReturnValue({ where: whereMock }),
+    });
+
+    await service.updateChapterAudio('s1', 1, 'audio');
+
+    expect(whereMock).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('returns latest versions for story chapters', async () => {
+    const chaptersData = [
+      { id: '1', chapterNumber: 1, title: 'v2', htmlContent: '', imageUri: null, audioUri: null, version: 2, createdAt: new Date(), updatedAt: new Date() },
+      { id: '2', chapterNumber: 1, title: 'v1', htmlContent: '', imageUri: null, audioUri: null, version: 1, createdAt: new Date(), updatedAt: new Date() },
+      { id: '3', chapterNumber: 2, title: 'b', htmlContent: '', imageUri: null, audioUri: null, version: 1, createdAt: new Date(), updatedAt: new Date() },
+    ];
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          orderBy: jest.fn().mockResolvedValue(chaptersData),
+        }),
+      }),
+    });
+
+    const result = await service.getStoryChapters('s1');
+    expect(result).toHaveLength(2);
+    expect(result[0].version).toBe(2);
+    expect(result[1].chapterNumber).toBe(2);
+  });
+});
+

--- a/src/tests/progress-tracker.test.ts
+++ b/src/tests/progress-tracker.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+jest.mock('@/config/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/utils', () => ({
+  retry: jest.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+const mockRunsService = {
+  getStepResult: jest.fn(),
+  getRun: jest.fn(),
+  getRunSteps: jest.fn(),
+};
+const mockStoryService = {
+  getStory: jest.fn(),
+  updateStoryCompletionPercentage: jest.fn(),
+  updateStoryStatus: jest.fn(),
+};
+
+jest.mock('../services/runs', () => ({
+  RunsService: jest.fn().mockImplementation(() => mockRunsService),
+}));
+
+jest.mock('../services/story', () => ({
+  StoryService: jest.fn().mockImplementation(() => mockStoryService),
+}));
+
+import { ProgressTrackerService } from '../services/progress-tracker';
+import { logger } from '@/config/logger';
+
+describe('ProgressTrackerService', () => {
+  let service: ProgressTrackerService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    service = new ProgressTrackerService();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('caches chapter counts from outline', async () => {
+    mockRunsService.getStepResult.mockResolvedValue({ detailJson: { chapters: [1, 2, 3] } });
+    const count1 = await (service as any).getChapterCount('r1');
+    const count2 = await (service as any).getChapterCount('r1');
+    expect(count1).toBe(3);
+    expect(count2).toBe(3);
+    expect(mockRunsService.getStepResult).toHaveBeenCalledTimes(1);
+  });
+
+  it('calculates progress based on completed steps', async () => {
+    mockRunsService.getRun.mockResolvedValue({ runId: 'r1', storyId: 's1', status: 'running', currentStep: 'write_chapter_1' });
+    mockRunsService.getStepResult.mockResolvedValue({ detailJson: { chapters: [{}, {}] } });
+    mockRunsService.getRunSteps.mockResolvedValue([
+      { stepName: 'generate_outline', status: 'completed' },
+      { stepName: 'write_chapter_1', status: 'completed' },
+    ]);
+
+    const result = await service.calculateProgress('r1');
+    expect(result.completedPercentage).toBe(14);
+    expect(result.totalEstimatedTime).toBeGreaterThan(200);
+    expect(result.completedSteps).toHaveLength(2);
+    expect(logger.debug).toHaveBeenCalled();
+  });
+
+  it('updates story progress and publishes on completion', async () => {
+    mockRunsService.getRun.mockResolvedValue({ runId: 'r1', storyId: 's1', status: 'completed', currentStep: 'done' });
+    jest.spyOn(service, 'calculateProgress').mockResolvedValue({
+      completedPercentage: 80,
+      totalEstimatedTime: 0,
+      elapsedTime: 0,
+      remainingTime: 0,
+      currentStep: 'done',
+      completedSteps: [],
+      totalSteps: 0,
+    });
+
+    await service.updateStoryProgress('r1');
+
+    expect(mockStoryService.updateStoryCompletionPercentage).toHaveBeenCalledWith('s1', 100);
+    expect(mockStoryService.updateStoryStatus).toHaveBeenCalledWith('s1', 'published');
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('throws when run not found', async () => {
+    mockRunsService.getRun.mockResolvedValue(null);
+    await expect(service.calculateProgress('bad')).rejects.toThrow('Run not found');
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+

--- a/src/tests/runs.test.ts
+++ b/src/tests/runs.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('@/config/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/db/workflows-db', () => ({
+  getWorkflowsDatabase: jest.fn(),
+  storyGenerationRuns: {},
+  storyGenerationSteps: {},
+}));
+
+import { RunsService } from '../services/runs';
+import { getWorkflowsDatabase } from '@/db/workflows-db';
+import { logger } from '@/config/logger';
+
+describe('RunsService', () => {
+  let service: RunsService;
+  let mockDb: any;
+
+  beforeEach(() => {
+    mockDb = {
+      insert: jest.fn(),
+      select: jest.fn(),
+      update: jest.fn(),
+    };
+    (getWorkflowsDatabase as jest.Mock).mockReturnValue(mockDb);
+    service = new RunsService();
+    jest.clearAllMocks();
+  });
+
+  it('creates a run', async () => {
+    const returningMock = jest.fn().mockResolvedValue([{ runId: 'r1', storyId: 's1', status: 'queued' }]);
+    mockDb.insert.mockReturnValue({
+      values: jest.fn().mockReturnValue({ returning: returningMock }),
+    });
+
+    const result = await service.createRun('s1', 'r1', 'exec1');
+
+    expect(result.runId).toBe('r1');
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('returns existing run in createOrGetRun', async () => {
+    const existing = { runId: 'r1', storyId: 's1', status: 'queued' };
+    const spy = jest.spyOn(service, 'getRun').mockResolvedValue(existing as any);
+
+    const result = await service.createOrGetRun('s1', 'r1');
+
+    expect(result).toBe(existing);
+    expect(spy).toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('updates run status transitions', async () => {
+    const returningMock = jest.fn().mockResolvedValue([{ runId: 'r1', status: 'running', currentStep: null }]);
+    const whereMock = jest.fn().mockReturnValue({ returning: returningMock });
+    const setMock = jest.fn().mockReturnValue({ where: whereMock });
+    mockDb.update.mockReturnValue({ set: setMock });
+
+    const result = await service.updateRun('r1', { status: 'running' });
+
+    expect(setMock.mock.calls[0][0].startedAt).toBeDefined();
+    expect(result.status).toBe('running');
+
+    returningMock.mockResolvedValue([{ runId: 'r1', status: 'completed', currentStep: null }]);
+    await service.updateRun('r1', { status: 'completed' });
+    expect(setMock.mock.calls[1][0].endedAt).toBeDefined();
+  });
+
+  it('retrieves run and steps', async () => {
+    mockDb.select
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([{ runId: 'r1', storyId: 's1' }]),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([{ stepName: 's', status: 'completed' }]),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([{ stepName: 'a', status: 'completed' }]),
+        }),
+      });
+
+    const run = await service.getRun('r1');
+    expect(run?.storyId).toBe('s1');
+
+    const steps = await service.getRunSteps('r1');
+    expect(steps).toHaveLength(1);
+
+    const step = await service.getStepResult('r1', 'a');
+    expect(step?.stepName).toBe('a');
+  });
+});
+

--- a/src/tests/story.test.ts
+++ b/src/tests/story.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('@/config/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/db/connection', () => ({
+  getDatabase: jest.fn(),
+}));
+
+jest.mock('@/shared/utils', () => ({
+  retry: jest.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
+import { StoryService } from '../services/story';
+import { getDatabase } from '@/db/connection';
+import { retry } from '@/shared/utils';
+import { logger } from '@/config/logger';
+
+describe('StoryService', () => {
+  let service: StoryService;
+  let mockDb: any;
+
+  beforeEach(() => {
+    mockDb = {
+      select: jest.fn(),
+      update: jest.fn(),
+    };
+    (getDatabase as jest.Mock).mockReturnValue(mockDb);
+    service = new StoryService();
+    jest.clearAllMocks();
+  });
+
+  it('should return true when story exists', async () => {
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([{ storyId: 's1' }]),
+        }),
+      }),
+    });
+
+    const result = await service.storyExists('s1');
+    expect(result).toBe(true);
+  });
+
+  it('should return false when story does not exist', async () => {
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const result = await service.storyExists('s1');
+    expect(result).toBe(false);
+  });
+
+  it('should return null for invalid storyId', async () => {
+    const result = await service.getStoryContext('');
+    expect(result).toBeNull();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('should load story context with characters', async () => {
+    const story = {
+      storyId: 's1',
+      authorId: 'a1',
+      title: 'Title',
+      plotDescription: null,
+      synopsis: null,
+      place: null,
+      additionalRequests: null,
+      targetAudience: null,
+      novelStyle: null,
+      graphicalStyle: null,
+      storyLanguage: 'en',
+      chapterCount: 2,
+    };
+    const characters = [
+      {
+        characterId: 'c1',
+        name: 'Hero',
+        type: null,
+        age: null,
+        traits: null,
+        characteristics: null,
+        physicalDescription: null,
+        role: 'lead',
+      },
+    ];
+
+    mockDb.select
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([story]),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          innerJoin: jest.fn().mockReturnValue({
+            where: jest.fn().mockResolvedValue(characters),
+          }),
+        }),
+      });
+
+    const result = await service.getStoryContext('s1');
+    expect(result?.story.title).toBe('Title');
+    expect(result?.characters).toHaveLength(1);
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('should update story URIs with retry', async () => {
+    const whereMock = jest.fn().mockResolvedValue(undefined);
+    const setMock = jest.fn().mockReturnValue({ where: whereMock });
+    mockDb.update.mockReturnValue({ set: setMock });
+
+    const updates = { htmlUri: 'html', hasAudio: true };
+    const result = await service.updateStoryUris('s1', updates);
+
+    expect(result).toBe(true);
+    expect(retry).toHaveBeenCalled();
+    expect(setMock).toHaveBeenCalledWith(updates);
+  });
+
+  it('should group chapters in getStoryForPrint', async () => {
+    const story = {
+      storyId: 's1',
+      title: 'Title',
+      customAuthor: null,
+      dedicationMessage: null,
+      coverUri: null,
+      backcoverUri: null,
+      chapterCount: 2,
+      storyLanguage: 'en',
+      createdAt: new Date(),
+      synopsis: null,
+      graphicalStyle: null,
+      targetAudience: null,
+    };
+
+    const chaptersData = [
+      { chapterNumber: 1, title: 'A2', content: 'v2', imageUri: 'i2', version: 2 },
+      { chapterNumber: 1, title: 'A', content: 'v1', imageUri: 'i1', version: 1 },
+      { chapterNumber: 2, title: 'B', content: 'v1', imageUri: 'i3', version: 1 },
+    ];
+
+    mockDb.select
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([story]),
+        }),
+      })
+      .mockReturnValueOnce({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            orderBy: jest.fn().mockResolvedValue(chaptersData),
+          }),
+        }),
+      });
+
+    const result = await service.getStoryForPrint('s1');
+    expect(result?.chapters).toHaveLength(2);
+    expect(result?.chapters[0].title).toBe('A2');
+    expect(logger.info).toHaveBeenCalled();
+  });
+});
+

--- a/src/tests/token-usage-tracking.test.ts
+++ b/src/tests/token-usage-tracking.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('@/config/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/db/workflows-db', () => ({
+  getWorkflowsDatabase: jest.fn(),
+  tokenUsageTracking: {},
+}));
+
+import { TokenUsageTrackingService } from '../services/token-usage-tracking';
+import { getWorkflowsDatabase } from '@/db/workflows-db';
+import { logger } from '@/config/logger';
+
+describe('TokenUsageTrackingService', () => {
+  let service: TokenUsageTrackingService;
+  let mockDb: any;
+
+  beforeEach(() => {
+    mockDb = {
+      insert: jest.fn(),
+      select: jest.fn(),
+    };
+    (getWorkflowsDatabase as jest.Mock).mockReturnValue(mockDb);
+    service = new TokenUsageTrackingService();
+    jest.clearAllMocks();
+  });
+
+  it('records usage with cost estimation', async () => {
+    const valuesMock = jest.fn().mockResolvedValue(undefined);
+    mockDb.insert.mockReturnValue({ values: valuesMock });
+
+    await service.recordUsage({
+      authorId: 'a1',
+      storyId: 's1',
+      action: 'chapter_writing',
+      aiModel: 'gpt-4',
+      inputTokens: 1000,
+      outputTokens: 500,
+      inputPromptJson: {},
+    });
+
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(valuesMock).toHaveBeenCalled();
+    const usageRecord = valuesMock.mock.calls[0][0];
+    expect(parseFloat(usageRecord.estimatedCostInEuros)).toBeCloseTo(0.0552);
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('calculates cost for OpenAI GPT-4 model', () => {
+    const estimation = (service as any).calculateCost({
+      provider: 'openai',
+      model: 'gpt-4',
+      inputTokens: 1000,
+      outputTokens: 500,
+      estimatedCostInEuros: 0,
+    });
+    expect(estimation.estimatedCostInEuros).toBeCloseTo(0.0552);
+  });
+
+  it('aggregates story usage', async () => {
+    const records = [
+      { action: 'chapter_writing', inputTokens: 100, outputTokens: 50, estimatedCostInEuros: '1' },
+      { action: 'image_generation', inputTokens: 0, outputTokens: 0, estimatedCostInEuros: '0.5' },
+    ];
+
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue(records),
+      }),
+    });
+
+    const result = await service.getStoryUsage('s1');
+    expect(result.totalTokens).toBe(150);
+    expect(result.totalCostEuros).toBeCloseTo(1.5);
+    expect(result.actionBreakdown.chapter_writing.tokens).toBe(150);
+    expect(result.actionBreakdown.image_generation.cost).toBeCloseTo(0.5);
+  });
+
+  it('aggregates author usage with story and action breakdown', async () => {
+    const records = [
+      { storyId: 's1', action: 'chapter_writing', inputTokens: 100, outputTokens: 50, estimatedCostInEuros: '1' },
+      { storyId: 's2', action: 'image_generation', inputTokens: 0, outputTokens: 0, estimatedCostInEuros: '0.5' },
+    ];
+
+    mockDb.select.mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue(records),
+      }),
+    });
+
+    const result = await service.getAuthorUsage('a1');
+    expect(result.totalTokens).toBe(150);
+    expect(result.storyBreakdown.s1.tokens).toBe(150);
+    expect(result.actionBreakdown.image_generation.cost).toBeCloseTo(0.5);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add ChaptersService tests verifying versioning, media updates, and latest chapter retrieval
- add RunsService tests covering run creation, status transitions, and data retrieval
- add ProgressTrackerService tests for chapter count caching, progress calculation, and publishing on completion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39e7673d88328b8d908fc4d2c9f31