### PR TITLE
fix: harden image failure handling telemetry

### DIFF
--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -3,7 +3,7 @@
  * Provider-agnostic endpoints for text and image generation
  */
 
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { Router } from 'express';
 import { z } from 'zod';
 import { validateImageRequest, generateImageFilename, formatImageError } from './ai-image-utils.js';
@@ -49,6 +49,104 @@ const storageService = getStorageService();
 const characterService = new CharacterService();
 const runsService = new RunsService();
 const imageSafetyService = new ImageSafetyService({ aiGateway });
+
+interface ImageRequestTelemetry {
+  storyId: string;
+  runId: string;
+  imageType: 'front_cover' | 'back_cover' | 'chapter' | undefined;
+  chapterNumber: number | undefined;
+  imageSlotKey: string;
+  promptFingerprint: string;
+  promptLength: number;
+  dimensions: string;
+  style: string | undefined;
+  existingImageUri: string | undefined;
+  duplicateRequestCountInProcess: number;
+}
+
+const IMAGE_REQUEST_TELEMETRY_TTL_MS = 60 * 60 * 1000;
+const imageRequestTelemetryCache = new Map<string, { count: number; lastSeenMs: number }>();
+
+function cleanupImageRequestTelemetryCache(nowMs: number): void {
+  for (const [key, value] of imageRequestTelemetryCache.entries()) {
+    if (nowMs - value.lastSeenMs > IMAGE_REQUEST_TELEMETRY_TTL_MS) {
+      imageRequestTelemetryCache.delete(key);
+    }
+  }
+}
+
+function hashImagePromptForTelemetry(params: {
+  prompt: string;
+  customInstructions: string;
+  imageType: string | undefined;
+  width: number | undefined;
+  height: number | undefined;
+  style: string | undefined;
+}): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        prompt: params.prompt,
+        customInstructions: params.customInstructions,
+        imageType: params.imageType,
+        width: params.width,
+        height: params.height,
+        style: params.style,
+      }),
+    )
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function registerImageRequestForTelemetry(imageSlotKey: string, promptFingerprint: string): number {
+  const nowMs = Date.now();
+  cleanupImageRequestTelemetryCache(nowMs);
+  const cacheKey = `${imageSlotKey}:${promptFingerprint}`;
+  const previous = imageRequestTelemetryCache.get(cacheKey);
+  const next = { count: (previous?.count || 0) + 1, lastSeenMs: nowMs };
+  imageRequestTelemetryCache.set(cacheKey, next);
+  return next.count;
+}
+
+async function getExistingImageUriForTelemetry(params: {
+  storyId: string;
+  imageType: 'front_cover' | 'back_cover' | 'chapter' | undefined;
+  chapterNumber: number | undefined;
+  coverUri: string | null | undefined;
+  backcoverUri: string | null | undefined;
+}): Promise<string | undefined> {
+  if (params.imageType === 'front_cover') return params.coverUri || undefined;
+  if (params.imageType === 'back_cover') return params.backcoverUri || undefined;
+
+  if (params.imageType === 'chapter' && typeof params.chapterNumber === 'number') {
+    try {
+      const db = (await import('@/db/connection.js')).getDatabase();
+      const { chapters } = await import('@/db/schema/index.js');
+      const { and, desc, eq } = await import('drizzle-orm');
+      const [chapter] = await db
+        .select({ imageUri: chapters.imageUri })
+        .from(chapters)
+        .where(
+          and(
+            eq(chapters.storyId, params.storyId),
+            eq(chapters.chapterNumber, params.chapterNumber),
+          ),
+        )
+        .orderBy(desc(chapters.version))
+        .limit(1);
+      return chapter?.imageUri || undefined;
+    } catch (error) {
+      logger.warn('Image telemetry existing chapter image lookup failed', {
+        storyId: params.storyId,
+        imageType: params.imageType,
+        chapterNumber: params.chapterNumber,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return undefined;
+}
 
 // Shared outline + character schema definitions
 const CharacterTypeEnum = z.enum(CHARACTER_TYPES);
@@ -1670,6 +1768,9 @@ router.post('/image', async (req, res) => {
   let promptRewriteError: string | undefined;
   let originalPrompt: string | undefined;
   let fallbackPromptUsed = false;
+  let imageRequestTelemetry: ImageRequestTelemetry | undefined;
+  let providerAttemptCount = 0;
+  let transientRetryCount = 0;
 
   try {
     const { prompt, storyId, runId, chapterNumber, imageType, width, height, style } =
@@ -1706,6 +1807,45 @@ router.post('/image', async (req, res) => {
       imageHeight = dimensions.height;
     }
 
+    const storyRecord = await storyService.getStory(storyId); // includes cover/backcover URIs
+    const existingImageUri = await getExistingImageUriForTelemetry({
+      storyId,
+      imageType,
+      chapterNumber,
+      coverUri: storyRecord?.coverUri,
+      backcoverUri: storyRecord?.backcoverUri,
+    });
+    const imageSlotKey = `${storyId}:${runId}:${imageType || 'unspecified'}:${chapterNumber || 'none'}`;
+    const promptFingerprint = hashImagePromptForTelemetry({
+      prompt,
+      customInstructions,
+      imageType,
+      width: imageWidth,
+      height: imageHeight,
+      style,
+    });
+    imageRequestTelemetry = {
+      storyId,
+      runId,
+      imageType,
+      chapterNumber,
+      imageSlotKey,
+      promptFingerprint,
+      promptLength: prompt.length,
+      dimensions: `${imageWidth || 'default'}x${imageHeight || 'default'}`,
+      style,
+      existingImageUri,
+      duplicateRequestCountInProcess: registerImageRequestForTelemetry(
+        imageSlotKey,
+        promptFingerprint,
+      ),
+    };
+    logger.info('Image generation request telemetry', {
+      ...imageRequestTelemetry,
+      existingImagePresent: !!existingImageUri,
+      idempotencyCacheStatus: existingImageUri ? 'existing_image_present' : 'miss_or_not_persisted',
+    });
+
     // Assemble up to five reference images (JPEG only), prioritizing character photo references,
     // then falling back to existing cover/previous-chapter references when capacity remains.
     currentStep = 'collecting_references';
@@ -1713,7 +1853,6 @@ router.post('/image', async (req, res) => {
     const seenReferenceFiles = new Set<string>();
     const MAX_REFERENCE_IMAGES = 5;
     try {
-      const storyRecord = await storyService.getStory(storyId); // includes cover/backcover URIs
       const storage = getStorageService();
       const bucketName = process.env.STORAGE_BUCKET_NAME;
 
@@ -1861,6 +2000,13 @@ router.post('/image', async (req, res) => {
       const { withRetry } = await import('@/shared/retry-utils.js');
       return await withRetry(
         async () => {
+          providerAttemptCount += 1;
+          logger.info('Image generation provider attempt telemetry', {
+            ...imageRequestTelemetry,
+            providerAttemptCount,
+            transientRetryCount,
+            promptVariant: promptToUse === originalPrompt ? 'original' : 'rewritten_or_fallback',
+          });
           return await aiGateway.getImageService(imageContext).generate(promptToUse, {
             ...(imageWidth && { width: imageWidth }),
             ...(imageHeight && { height: imageHeight }),
@@ -1880,12 +2026,12 @@ router.post('/image', async (req, res) => {
           maxDelayMs: 10000,
           jitterMs: 1000,
           onRetry: (attempt, error) => {
+            transientRetryCount += 1;
             logger.warn('Image generation transient retry', {
-              storyId,
-              runId,
-              imageType,
-              chapterNumber,
+              ...imageRequestTelemetry,
               attempt,
+              providerAttemptCount,
+              transientRetryCount,
               error: error instanceof Error ? error.message : String(error),
               errorCode: (error as any)?.code,
             });
@@ -1973,6 +2119,28 @@ router.post('/image', async (req, res) => {
     currentStep = 'uploading_to_storage';
     const imageUrl = await storageService.uploadFile(filename, imageBuffer, 'image/jpeg');
 
+    logger.info('Image generation completion telemetry', {
+      ...imageRequestTelemetry,
+      filename,
+      imageUrl,
+      imageSizeBytes: imageBuffer.length,
+      providerAttemptCount,
+      transientRetryCount,
+      promptRewriteAttempted,
+      promptRewriteApplied,
+      fallbackPromptUsed,
+      referenceImageCount: referenceImages.length,
+      referenceImageSources: referenceImages.map((r) => r.source),
+      finalPromptFingerprint: hashImagePromptForTelemetry({
+        prompt: finalPrompt,
+        customInstructions,
+        imageType,
+        width: imageWidth,
+        height: imageHeight,
+        style,
+      }),
+    });
+
     res.json({
       success: true,
       storyId,
@@ -2021,6 +2189,21 @@ router.post('/image', async (req, res) => {
     if ((error as any)?.fallbackAttempted) resp.fallbackAttempted = true;
     if ((error as any)?.fallbackError) resp.fallbackError = (error as any).fallbackError;
     if (fallbackPromptUsed) resp.fallbackPromptUsed = true;
+
+    logger.error('Image generation failure telemetry', {
+      ...imageRequestTelemetry,
+      currentStep,
+      statusCode,
+      providerAttemptCount,
+      transientRetryCount,
+      promptRewriteAttempted,
+      promptRewriteApplied,
+      fallbackPromptUsed,
+      error: error instanceof Error ? error.message : String(error),
+      errorCode: errorDetails.code,
+      errorCategory: errorDetails.category,
+    });
+
     res.status(statusCode).json(resp);
   }
 });

--- a/src/services/progress-tracker.ts
+++ b/src/services/progress-tracker.ts
@@ -487,6 +487,10 @@ export class ProgressTrackerService {
   }
 
   private shouldDispatchStoryCreatedEmail(metadata: unknown): boolean {
+    if (this.isStoryCreatedEmailSuppressed(metadata)) {
+      return false;
+    }
+
     const serviceCode = this.extractServiceCode(metadata);
     if (!serviceCode) {
       return true;
@@ -494,6 +498,15 @@ export class ProgressTrackerService {
 
     // Only send story-created emails for the core story generation workflow.
     return !this.notificationExclusionServiceCodes.has(serviceCode);
+  }
+
+  private isStoryCreatedEmailSuppressed(metadata: unknown): boolean {
+    if (!metadata || typeof metadata !== 'object') {
+      return false;
+    }
+
+    const root = metadata as Record<string, unknown>;
+    return root.suppressStoryCreatedEmail === true;
   }
 
   private extractServiceCode(metadata: unknown): string | undefined {

--- a/src/tests/progress-tracker.test.ts
+++ b/src/tests/progress-tracker.test.ts
@@ -184,4 +184,31 @@ describe('ProgressTrackerService', () => {
       }),
     );
   });
+
+  it('suppresses story-created email when recovery metadata requests it', async () => {
+    const runId = 'r-suppressed';
+
+    mockRunsService.getRun.mockResolvedValue({
+      runId,
+      storyId: 's-suppressed',
+      status: 'completed',
+      currentStep: 'done',
+      metadata: { serviceCode: 'storyGeneration', suppressStoryCreatedEmail: true },
+    });
+
+    jest.spyOn(service, 'calculateProgress').mockResolvedValue({
+      completedPercentage: 100,
+      totalEstimatedTime: 0,
+      elapsedTime: 0,
+      remainingTime: 0,
+      currentStep: 'done',
+      completedSteps: [],
+      totalSteps: 0,
+    });
+
+    await service.updateStoryProgress(runId);
+    await Promise.resolve();
+
+    expect(mockedSendStoryCreatedEmail).not.toHaveBeenCalled();
+  });
 });

--- a/workflows/story-generation.yaml
+++ b/workflows/story-generation.yaml
@@ -339,7 +339,7 @@ main:
                                         call: sys.log
                                         args:
                                           severity: WARNING
-                                          text: '${"Front cover attempt " + string(attempt) + " failed, retrying after " + string(frontCoverRetryDelay) + "s: " + frontCoverAttemptError.message}'
+                                          text: '${"Front cover attempt " + string(attempt) + " failed, retrying after " + string(frontCoverRetryDelay) + "s: " + default(map.get(frontCoverAttemptError, "message"), "unknown")}'
                                     - delayFrontCoverRetry:
                                         call: sys.sleep
                                         args:
@@ -352,10 +352,10 @@ main:
                         call: sys.log
                         args:
                           severity: WARNING
-                          text: '${"Front cover generation failed after retries: " + frontCoverError.message}'
+                          text: '${"Front cover generation failed after retries: " + default(map.get(frontCoverError, "message"), "unknown")}'
                     - flagFrontCoverFailure:
                         assign:
-                          - frontCoverFailureReason: ${frontCoverError.message}
+                          - frontCoverFailureReason: ${default(map.get(frontCoverError, "message"), "unknown")}
                           - frontCoverFailureCode: ${default(map.get(frontCoverError, "code"), "unknown")}
 
             - handleFrontCoverOutcome:
@@ -379,13 +379,13 @@ main:
                     steps:
                       - captureFrontCoverFailure:
                           assign:
-                            - frontCoverFailureReason: ${if(frontCoverLastError != null, frontCoverLastError.message, "unknown")}
-                            - frontCoverFailureCode: ${if(frontCoverLastError != null, frontCoverLastError.code, null)}
+                            - frontCoverFailureReason: ${if(frontCoverLastError != null, default(map.get(frontCoverLastError, "message"), "unknown"), "unknown")}
+                            - frontCoverFailureCode: ${if(frontCoverLastError != null, default(map.get(frontCoverLastError, "code"), "unknown"), "unknown")}
                       - logFrontCoverSkip:
                           call: sys.log
                           args:
                             severity: WARNING
-                            text: '${"Front cover image unavailable after retries; continuing pipeline. Last error: " + if(frontCoverLastError != null, frontCoverLastError.message, "unknown")}'
+                            text: '${"Front cover image unavailable after retries; continuing pipeline. Last error: " + frontCoverFailureReason + " (code: " + string(frontCoverFailureCode) + ")"}'
 
             # 5. Generate book back cover
             - setBackCoverStep:
@@ -458,7 +458,7 @@ main:
                                         call: sys.log
                                         args:
                                           severity: WARNING
-                                          text: '${"Back cover attempt " + string(attempt) + " failed, retrying after " + string(backCoverRetryDelay) + "s: " + backCoverAttemptError.message}'
+                                          text: '${"Back cover attempt " + string(attempt) + " failed, retrying after " + string(backCoverRetryDelay) + "s: " + default(map.get(backCoverAttemptError, "message"), "unknown")}'
                                     - delayBackCoverRetry:
                                         call: sys.sleep
                                         args:
@@ -470,10 +470,10 @@ main:
                         call: sys.log
                         args:
                           severity: WARNING
-                          text: '${"Back cover generation failed after retries: " + backCoverError.message}'
+                          text: '${"Back cover generation failed after retries: " + default(map.get(backCoverError, "message"), "unknown")}'
                     - flagBackCoverFailure:
                         assign:
-                          - backCoverFailureReason: ${backCoverError.message}
+                          - backCoverFailureReason: ${default(map.get(backCoverError, "message"), "unknown")}
                           - backCoverFailureCode: ${default(map.get(backCoverError, "code"), "unknown")}
 
             - handleBackCoverOutcome:
@@ -497,13 +497,13 @@ main:
                     steps:
                       - captureBackCoverFailure:
                           assign:
-                            - backCoverFailureReason: ${if(backCoverLastError != null, backCoverLastError.message, "unknown")}
-                            - backCoverFailureCode: ${if(backCoverLastError != null, backCoverLastError.code, null)}
+                            - backCoverFailureReason: ${if(backCoverLastError != null, default(map.get(backCoverLastError, "message"), "unknown"), "unknown")}
+                            - backCoverFailureCode: ${if(backCoverLastError != null, default(map.get(backCoverLastError, "code"), "unknown"), "unknown")}
                       - logBackCoverSkip:
                           call: sys.log
                           args:
                             severity: WARNING
-                            text: '${"Back cover image unavailable after retries; continuing pipeline. Last error: " + if(backCoverLastError != null, backCoverLastError.message, "unknown")}'
+                            text: '${"Back cover image unavailable after retries; continuing pipeline. Last error: " + backCoverFailureReason + " (code: " + string(backCoverFailureCode) + ")"}'
 
             # 6. Generate chapter images sequentially
             - setImagesStep:
@@ -581,7 +581,7 @@ main:
                                                 call: sys.log
                                                 args:
                                                   severity: WARNING
-                                                  text: '${"Chapter " + string(chapterNum) + " image attempt " + string(attempt) + " failed, retrying after " + string(chapterImageRetryDelay) + "s: " + chapterImageAttemptError.message}'
+                                                  text: '${"Chapter " + string(chapterNum) + " image attempt " + string(attempt) + " failed, retrying after " + string(chapterImageRetryDelay) + "s: " + default(map.get(chapterImageAttemptError, "message"), "unknown")}'
                                             - maybeDelayChapterImageRetry:
                                                 switch:
                                                   - condition: ${attempt < chapterImageMaxAttempts}
@@ -598,10 +598,10 @@ main:
                                 call: sys.log
                                 args:
                                   severity: WARNING
-                                  text: '${"Chapter " + string(chapterNum) + " image failed unexpectedly: " + chapterImageError.message}'
+                                  text: '${"Chapter " + string(chapterNum) + " image failed unexpectedly: " + default(map.get(chapterImageError, "message"), "unknown")}'
                             - flagChapterImageFailure:
                                 assign:
-                                  - chapterImageFailureReason: ${chapterImageError.message}
+                                  - chapterImageFailureReason: ${default(map.get(chapterImageError, "message"), "unknown")}
                                   - chapterImageFailureCode: ${default(map.get(chapterImageError, "code"), "unknown")}
                     - handleChapterImageOutcome:
                         switch:
@@ -625,13 +625,13 @@ main:
                             steps:
                               - captureChapterImageFailure:
                                   assign:
-                                    - chapterImageFailureReason: ${if(chapterImageLastError != null, chapterImageLastError.message, "unknown")}
-                                    - chapterImageFailureCode: ${if(chapterImageLastError != null, chapterImageLastError.code, null)}
+                                    - chapterImageFailureReason: ${if(chapterImageLastError != null, default(map.get(chapterImageLastError, "message"), "unknown"), "unknown")}
+                                    - chapterImageFailureCode: ${if(chapterImageLastError != null, default(map.get(chapterImageLastError, "code"), "unknown"), "unknown")}
                               - logChapterImageSkip:
                                   call: sys.log
                                   args:
                                     severity: WARNING
-                                    text: '${"Skipping image persistence for chapter " + string(chapterNum) + " due to repeated failures. Last error: " + if(chapterImageLastError != null, chapterImageLastError.message, "unknown")}'
+                                    text: '${"Skipping image persistence for chapter " + string(chapterNum) + " due to repeated failures. Last error: " + chapterImageFailureReason + " (code: " + string(chapterImageFailureCode) + ")"}'
 
             # 8. Mark run completed
             - clearContextBestEffort:


### PR DESCRIPTION
## Summary

- hardens front-cover, back-cover, and chapter-image workflow failure handling so missing error fields do not mask the original failure with `KeyError: key not found: code`
- adds image-generation observability for prompt fingerprints, image slot keys, existing persisted assets, duplicate in-process requests, provider attempts, transient retries, and completion/failure metadata
- keeps supervised recovery safe by adding `suppressStoryCreatedEmail` metadata handling and a focused regression test

## Operational scope

This PR is code-only. It does **not** deploy, restart services, publish Pub/Sub, mutate production DB state, run story recovery, or contact customers.

Recovery for `61bbf104` / `d605f41e` still needs separate review + explicit approval after this fix is validated and deployed.

## Validation

- `npm run typecheck`
- `npm run lint -- --quiet`
- YAML parse for `workflows/story-generation.yaml`
- `npm test -- src/tests/progress-tracker.test.ts src/tests/openai-image-service.test.ts src/tests/token-usage-tracking.test.ts --runInBand`
- `git diff --check`
