### PR TITLE
[codex] fix TTS voice normalization and audiobook error handling

### DIFF
--- a/src/services/tts-utils.ts
+++ b/src/services/tts-utils.ts
@@ -15,6 +15,31 @@ export interface TTSConfig {
   language: string;
 }
 
+const OPENAI_TTS_VOICES = new Set([
+  'alloy',
+  'ash',
+  'ballad',
+  'coral',
+  'echo',
+  'fable',
+  'nova',
+  'onyx',
+  'sage',
+  'shimmer',
+  'verse',
+]);
+
+const GEMINI_TTS_VOICES = new Set([
+  'Charon',
+  'Aoede',
+  'Puck',
+  'Kore',
+  'Fenrir',
+  'Orus',
+  'Zephyr',
+  'Sulafat',
+]);
+
 /**
  * Get default voice for a given TTS provider
  */
@@ -27,6 +52,25 @@ export function getDefaultVoice(provider: TTSProvider): string {
     default:
       return 'coral';
   }
+}
+
+/**
+ * Normalize request-level voice overrides so voices from one provider are not
+ * forwarded to another provider's API.
+ */
+export function normalizeTTSVoice(
+  provider: TTSProvider,
+  requestedVoice: string | undefined,
+  fallbackVoice = getDefaultVoice(provider),
+): { voice: string; wasFallback: boolean } {
+  const voice = requestedVoice?.trim() || fallbackVoice;
+  const allowedVoices = provider === 'google-genai' ? GEMINI_TTS_VOICES : OPENAI_TTS_VOICES;
+
+  if (allowedVoices.has(voice)) {
+    return { voice, wasFallback: false };
+  }
+
+  return { voice: fallbackVoice, wasFallback: true };
 }
 
 /**

--- a/src/services/tts.ts
+++ b/src/services/tts.ts
@@ -16,6 +16,7 @@ import { getEnvironment } from '@/config/environment.js';
 import { countWords, extractTargetAge } from '@/shared/utils.js';
 import {
   getTTSConfig,
+  normalizeTTSVoice,
   estimateDuration,
   getAudioFilename,
   buildFirstChapterAudioText,
@@ -95,6 +96,17 @@ export class TTSService {
       if (voice) {
         config.voice = voice;
       }
+      const normalizedVoice = normalizeTTSVoice(config.provider, config.voice);
+      if (normalizedVoice.wasFallback) {
+        logger.warn('Ignoring unsupported TTS voice for provider', {
+          storyId,
+          chapterNumber,
+          provider: config.provider,
+          requestedVoice: config.voice,
+          fallbackVoice: normalizedVoice.voice,
+        });
+      }
+      config.voice = normalizedVoice.voice;
 
       // Use story language from parameters or story record
       const storyLanguage = extraParams?.storyLanguage || story.storyLanguage || 'en-US';

--- a/src/tests/tts-production-improvements.test.ts
+++ b/src/tests/tts-production-improvements.test.ts
@@ -8,6 +8,7 @@ import './setup/environment-mock';
 
 // Use relative path for the import to avoid path resolution issues during tests
 import { AudioPromptService } from '../services/audio-prompt.js';
+import { normalizeTTSVoice } from '../services/tts-utils.js';
 
 describe('TTS Production Improvements', () => {
   beforeEach(() => {
@@ -81,6 +82,26 @@ describe('TTS Production Improvements', () => {
 
       expect(speed).toBeGreaterThanOrEqual(0.25);
       expect(speed).toBeLessThanOrEqual(4.0);
+    });
+  });
+
+  describe('TTS voice normalization', () => {
+    test('should fall back when an OpenAI voice is requested for Gemini TTS', () => {
+      const result = normalizeTTSVoice('google-genai', 'fable');
+
+      expect(result).toEqual({ voice: 'Charon', wasFallback: true });
+    });
+
+    test('should keep valid Gemini voices', () => {
+      const result = normalizeTTSVoice('google-genai', 'Aoede');
+
+      expect(result).toEqual({ voice: 'Aoede', wasFallback: false });
+    });
+
+    test('should keep valid OpenAI voices', () => {
+      const result = normalizeTTSVoice('openai', 'fable');
+
+      expect(result).toEqual({ voice: 'fable', wasFallback: false });
     });
   });
 

--- a/workflows/audiobook-generation.yaml
+++ b/workflows/audiobook-generation.yaml
@@ -206,11 +206,11 @@ main:
                   body:
                     status: 'failed'
                     failedAt: ${time.format(sys.now())}
-                    error: ${audioError.message}
+                    error: ${string(audioError)}
 
             - returnAudioError:
                 return:
                   success: false
-                  error: ${audioError.message}
+                  error: ${string(audioError)}
                   storyId: ${storyId}
                   runId: ${runId}


### PR DESCRIPTION
## Summary

- normalize request-level TTS voice overrides against the active provider so OpenAI voices like `fable` are not sent to Google GenAI
- keep valid Gemini/OpenAI voices unchanged and log fallback decisions
- make audiobook workflow failure handling robust when `audioError` is a string instead of an object

## Impact

This prevents stale OpenAI voice overrides such as `fable` from being sent to the Google GenAI TTS path, so audiobook retries use a provider-supported fallback instead of failing with a provider 404. It also lets audiobook failure handling persist a failed state when Workflows surfaces `audioError` as a string.

## Rollback

Revert this PR. No schema or data migration is involved. If rollback is needed after deploy, keep story audiobook retries paused until the previous TTS provider/voice configuration is restored and validated.

## Validation

- `npm test -- src/tests/tts-production-improvements.test.ts`
- `npm run typecheck`