### PR TITLE
fix: omit top_p from OpenAI image responses

### DIFF
--- a/src/ai/providers/openai/image.ts
+++ b/src/ai/providers/openai/image.ts
@@ -215,7 +215,6 @@ export class OpenAIImageService implements IImageGenerationService {
           toolConfig,
           temperature: 1,
           maxOutputTokens: 8192,
-          topP: 1,
           store: true,
         });
       }
@@ -278,7 +277,6 @@ export class OpenAIImageService implements IImageGenerationService {
         tools: [toolConfig],
         temperature: 1,
         max_output_tokens: 8192,
-        top_p: 1,
         store: true,
         // Chain sequential image generations for implicit style continuity
         ...(this.lastResponseId ? { previous_response_id: this.lastResponseId } : {}),

--- a/src/tests/openai-image-service.test.ts
+++ b/src/tests/openai-image-service.test.ts
@@ -58,6 +58,23 @@ describe('OpenAIImageService', () => {
     expect(request.tools[0]).not.toHaveProperty('input_fidelity');
   });
 
+  it('does not send top_p for image generation responses requests', async () => {
+    const service = new OpenAIImageService({
+      apiKey: 'test-key',
+      model: 'gpt-5.5',
+      imageModel: 'gpt-image-2',
+    });
+
+    await service.generate('Generate a chapter illustration.', {
+      systemPrompt: 'Generate story art.',
+      width: 1024,
+      height: 1536,
+    });
+
+    const request = mockResponsesCreate.mock.calls[0]?.[0] as any;
+    expect(request).not.toHaveProperty('top_p');
+  });
+
   it('keeps input_fidelity for gpt-image-1.5 image generation tool requests', async () => {
     const service = new OpenAIImageService({
       apiKey: 'test-key',


### PR DESCRIPTION
## Summary
- omit `top_p` / `topP` from OpenAI Responses API image-generation requests
- add a focused regression test for the OpenAI image service request payload

## Verification
- `npm test -- --runInBand src/tests/openai-image-service.test.ts`
- `npm run typecheck`

## Incident follow-up
- Story `b73acfa9-e5c3-4a2d-aabd-6992af1067d9` (`Clara's Inkwell Adventure`) is published with 6 chapters, but all 6 latest chapter rows currently have no `image_uri`.
- After deploy, run a targeted image retry for chapters 1-6 before considering the customer case closed.
